### PR TITLE
fix: ensure header changes trigger recompilation in BuildCache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cudaforge"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Guoqing Bao"]
 description = """

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -548,7 +548,10 @@ impl KernelBuilder {
         let nvcc_threads = self.parallel.nvcc_threads();
         let watch_hash = hash_paths(self.sources.watch_paths());
         let mut cache = BuildCache::load(&self.out_dir);
-        let args_hash = hash_args(&self.extra_args);
+
+        let mut all_args = self.extra_args.clone();
+        all_args.extend(dep_args.clone());
+        let args_hash = hash_args(&all_args);
 
         let mut compile_jobs = Vec::new();
         for kernel_file in &kernel_files {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,7 @@
 use crate::compute_cap::{ComputeCapability, GpuArch};
 use crate::dependency::DependencyManager;
 use crate::error::{Error, Result};
-use crate::hash::{hash_args, BuildCache};
+use crate::hash::{hash_args, hash_paths, BuildCache};
 use crate::parallel::ParallelConfig;
 use crate::source::SourceSelector;
 use crate::toolkit::CudaToolkit;
@@ -343,6 +343,9 @@ impl KernelBuilder {
         all_args.extend(dep_args.clone());
         let args_hash = hash_args(&all_args);
 
+        // Calculate watch hash for cache
+        let watch_hash = hash_paths(self.sources.watch_paths());
+
         // Determine which files need compilation
         let mut compile_jobs: Vec<(PathBuf, PathBuf, GpuArch)> = Vec::new();
         let mut all_obj_files: Vec<PathBuf> = Vec::new();
@@ -364,6 +367,7 @@ impl KernelBuilder {
                     &obj_file,
                     &gpu_arch.to_nvcc_arch(),
                     &args_hash,
+                    &watch_hash,
                 )
             {
                 continue;
@@ -475,7 +479,13 @@ impl KernelBuilder {
         // Update cache for compiled files
         if self.incremental {
             for (kernel_file, obj_file, gpu_arch) in &compile_jobs {
-                cache.update(kernel_file, obj_file, &gpu_arch.to_nvcc_arch(), &args_hash)?;
+                cache.update(
+                    kernel_file,
+                    &obj_file,
+                    &gpu_arch.to_nvcc_arch(),
+                    &args_hash,
+                    &watch_hash,
+                )?;
             }
             cache.save(&self.out_dir)?;
         }
@@ -536,6 +546,9 @@ impl KernelBuilder {
         let dep_args = self.dependencies.fetch_all(&self.out_dir)?;
         let ccbin_env = std::env::var("NVCC_CCBIN").ok();
         let nvcc_threads = self.parallel.nvcc_threads();
+        let watch_hash = hash_paths(self.sources.watch_paths());
+        let mut cache = BuildCache::load(&self.out_dir);
+        let args_hash = hash_args(&self.extra_args);
 
         kernel_files
             .par_iter()
@@ -550,19 +563,17 @@ impl KernelBuilder {
                     .out_dir
                     .join(kernel_file.with_extension("ptx").file_name().unwrap());
 
-                // Check if output is current
-                if output_file.exists() {
-                    if let (Ok(out_meta), Ok(in_meta)) =
-                        (output_file.metadata(), kernel_file.metadata())
-                    {
-                        if let (Ok(out_time), Ok(in_time)) =
-                            (out_meta.modified(), in_meta.modified())
-                        {
-                            if out_time.duration_since(in_time).is_ok() {
-                                return Ok(());
-                            }
-                        }
-                    }
+                // Check if output is current using BuildCache
+                if self.incremental
+                    && !cache.needs_rebuild(
+                        kernel_file,
+                        &output_file,
+                        &gpu_arch.to_nvcc_arch(),
+                        &args_hash,
+                        &watch_hash,
+                    )
+                {
+                    return Ok(());
                 }
 
                 let gencode_arg = gpu_arch.to_gencode_arg();
@@ -619,6 +630,29 @@ impl KernelBuilder {
                 Ok(())
             })?;
 
+        // Update cache for PTX files
+        if self.incremental {
+            for kernel_file in &kernel_files {
+                let filename = kernel_file
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("");
+                let gpu_arch = self.compute_cap.get_for_file(filename)?;
+                let output_file = self
+                    .out_dir
+                    .join(kernel_file.with_extension("ptx").file_name().unwrap());
+
+                cache.update(
+                    kernel_file,
+                    &output_file,
+                    &gpu_arch.to_nvcc_arch(),
+                    &args_hash,
+                    &watch_hash,
+                )?;
+            }
+            cache.save(&self.out_dir)?;
+        }
+
         Ok(PtxOutput {
             paths: kernel_files,
             out_dir: self.out_dir.clone(),
@@ -667,5 +701,68 @@ impl PtxOutput {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+
+    #[test]
+    fn test_incremental_rebuild_on_header_change() {
+        // Skip test if nvcc is not available (e.g. in some CI environments)
+        if crate::toolkit::CudaToolkit::detect().is_err() {
+            return;
+        }
+
+        // Use a semi-unique directory in the system temp folder
+        let mut root = std::env::temp_dir();
+        root.push(format!("cudaforge-test-{}", std::process::id()));
+        
+        // Ensure clean state
+        if root.exists() {
+            let _ = fs::remove_dir_all(&root);
+        }
+        fs::create_dir_all(&root).unwrap();
+
+        let out_dir = root.join("out");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&out_dir).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let cu_file = src_dir.join("kernel.cu");
+        let cuh_file = src_dir.join("header.cuh");
+        let lib_file = out_dir.join("libkernels.a");
+
+        // Create initial version
+        fs::write(&cu_file, "#include \"header.cuh\"\nextern \"C\" __global__ void add() {}").unwrap();
+        fs::write(&cuh_file, "// version 1").unwrap();
+
+        let builder = KernelBuilder::new()
+            .source_files(vec![&cu_file])
+            .watch(vec![&cuh_file])
+            .out_dir(&out_dir);
+        
+        // First build
+        builder.build_lib(&lib_file).expect("First build failed");
+        let mtime1 = fs::metadata(&lib_file).expect("Lib file should exist").modified().unwrap();
+
+        std::thread::sleep(Duration::from_millis(1100));
+
+        // Modify the watched header
+        fs::write(&cuh_file, "// version 2").unwrap();
+
+        // Second build - should trigger recompilation
+        builder.build_lib(&lib_file).expect("Second build failed");
+        let mtime2 = fs::metadata(&lib_file).expect("Lib file should exist after second build").modified().unwrap();
+
+        let recompiled = mtime2 > mtime1;
+        
+        // Cleanup BEFORE assertion so we don't leave mess on failure
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(recompiled, "Recompilation was NOT triggered by header change!");
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -389,7 +389,7 @@ impl KernelBuilder {
 
         // Get target info
         let target = std::env::var("TARGET").ok();
-        let is_msvc = target.as_ref().map_or(false, |t| t.contains("msvc"));
+        let is_msvc = target.as_ref().is_some_and(|t| t.contains("msvc"));
         let ccbin_env = std::env::var("NVCC_CCBIN").ok();
         let nvcc_threads = self.parallel.nvcc_threads();
 
@@ -481,7 +481,7 @@ impl KernelBuilder {
             for (kernel_file, obj_file, gpu_arch) in &compile_jobs {
                 cache.update(
                     kernel_file,
-                    &obj_file,
+                    obj_file,
                     &gpu_arch.to_nvcc_arch(),
                     &args_hash,
                     &watch_hash,
@@ -701,68 +701,5 @@ impl PtxOutput {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use std::time::Duration;
-
-    #[test]
-    fn test_incremental_rebuild_on_header_change() {
-        // Skip test if nvcc is not available (e.g. in some CI environments)
-        if crate::toolkit::CudaToolkit::detect().is_err() {
-            return;
-        }
-
-        // Use a semi-unique directory in the system temp folder
-        let mut root = std::env::temp_dir();
-        root.push(format!("cudaforge-test-{}", std::process::id()));
-        
-        // Ensure clean state
-        if root.exists() {
-            let _ = fs::remove_dir_all(&root);
-        }
-        fs::create_dir_all(&root).unwrap();
-
-        let out_dir = root.join("out");
-        let src_dir = root.join("src");
-        fs::create_dir_all(&out_dir).unwrap();
-        fs::create_dir_all(&src_dir).unwrap();
-
-        let cu_file = src_dir.join("kernel.cu");
-        let cuh_file = src_dir.join("header.cuh");
-        let lib_file = out_dir.join("libkernels.a");
-
-        // Create initial version
-        fs::write(&cu_file, "#include \"header.cuh\"\nextern \"C\" __global__ void add() {}").unwrap();
-        fs::write(&cuh_file, "// version 1").unwrap();
-
-        let builder = KernelBuilder::new()
-            .source_files(vec![&cu_file])
-            .watch(vec![&cuh_file])
-            .out_dir(&out_dir);
-        
-        // First build
-        builder.build_lib(&lib_file).expect("First build failed");
-        let mtime1 = fs::metadata(&lib_file).expect("Lib file should exist").modified().unwrap();
-
-        std::thread::sleep(Duration::from_millis(1100));
-
-        // Modify the watched header
-        fs::write(&cuh_file, "// version 2").unwrap();
-
-        // Second build - should trigger recompilation
-        builder.build_lib(&lib_file).expect("Second build failed");
-        let mtime2 = fs::metadata(&lib_file).expect("Lib file should exist after second build").modified().unwrap();
-
-        let recompiled = mtime2 > mtime1;
-        
-        // Cleanup BEFORE assertion so we don't leave mess on failure
-        let _ = fs::remove_dir_all(&root);
-
-        assert!(recompiled, "Recompilation was NOT triggered by header change!");
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -377,7 +377,7 @@ impl KernelBuilder {
         }
 
         if compile_jobs.is_empty() && out_file.exists() {
-            println!("cargo:warning=All kernels up-to-date, skipping compilation");
+            println!("cargo:warning=All library kernels up-to-date, skipping compilation");
             return Ok(());
         }
 
@@ -550,32 +550,51 @@ impl KernelBuilder {
         let mut cache = BuildCache::load(&self.out_dir);
         let args_hash = hash_args(&self.extra_args);
 
-        kernel_files
-            .par_iter()
-            .try_for_each(|kernel_file| -> Result<()> {
-                let filename = kernel_file
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("");
-                let gpu_arch = self.compute_cap.get_for_file(filename)?;
+        let mut compile_jobs = Vec::new();
+        for kernel_file in &kernel_files {
+            let filename = kernel_file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            let gpu_arch = self.compute_cap.get_for_file(filename)?;
 
-                let output_file = self
-                    .out_dir
-                    .join(kernel_file.with_extension("ptx").file_name().unwrap());
+            let output_file = self
+                .out_dir
+                .join(kernel_file.with_extension("ptx").file_name().unwrap());
 
-                // Check if output is current using BuildCache
-                if self.incremental
-                    && !cache.needs_rebuild(
-                        kernel_file,
-                        &output_file,
-                        &gpu_arch.to_nvcc_arch(),
-                        &args_hash,
-                        &watch_hash,
-                    )
-                {
-                    return Ok(());
-                }
+            // Check if output is current using BuildCache
+            if self.incremental
+                && !cache.needs_rebuild(
+                    kernel_file,
+                    &output_file,
+                    &gpu_arch.to_nvcc_arch(),
+                    &args_hash,
+                    &watch_hash,
+                )
+            {
+                continue;
+            }
 
+            compile_jobs.push((kernel_file, output_file, gpu_arch));
+        }
+
+        if compile_jobs.is_empty() {
+            println!("cargo:warning=All PTX kernels up-to-date, skipping compilation");
+            return Ok(PtxOutput {
+                paths: kernel_files,
+                out_dir: self.out_dir.clone(),
+            });
+        }
+
+        println!(
+            "cargo:warning=Compiling {} of {} PTX kernels",
+            compile_jobs.len(),
+            kernel_files.len()
+        );
+
+        // Compile in parallel
+        compile_jobs.par_iter().try_for_each(
+            |(kernel_file, _output_file, gpu_arch)| -> Result<()> {
                 let gencode_arg = gpu_arch.to_gencode_arg();
 
                 let mut command = Command::new(&toolkit.nvcc_path);
@@ -612,13 +631,13 @@ impl KernelBuilder {
                     .map_err(|e| Error::NvccNotFound(format!("Failed to spawn nvcc: {}", e)))?
                     .wait_with_output()
                     .map_err(|e| Error::CompilationFailed {
-                        path: kernel_file.clone(),
+                        path: kernel_file.to_path_buf(),
                         message: e.to_string(),
                     })?;
 
                 if !output.status.success() {
                     return Err(Error::CompilationFailed {
-                        path: kernel_file.clone(),
+                        path: kernel_file.to_path_buf(),
                         message: format!(
                             "nvcc error:\n{}\n{}",
                             String::from_utf8_lossy(&output.stdout),
@@ -628,7 +647,8 @@ impl KernelBuilder {
                 }
 
                 Ok(())
-            })?;
+            },
+        )?;
 
         // Update cache for PTX files
         if self.incremental {
@@ -701,5 +721,81 @@ impl PtxOutput {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+
+    #[test]
+    fn test_incremental_rebuild_on_header_change() {
+        // Skip test if nvcc is not available (e.g. in some CI environments)
+        if crate::toolkit::CudaToolkit::detect().is_err() {
+            return;
+        }
+
+        // Use a semi-unique directory in the system temp folder
+        let mut root = std::env::temp_dir();
+        root.push(format!("cudaforge-test-{}", std::process::id()));
+
+        // Ensure clean state
+        if root.exists() {
+            let _ = fs::remove_dir_all(&root);
+        }
+        fs::create_dir_all(&root).unwrap();
+
+        let out_dir = root.join("out");
+        let src_dir = root.join("src");
+        fs::create_dir_all(&out_dir).unwrap();
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let cu_file = src_dir.join("kernel.cu");
+        let cuh_file = src_dir.join("header.cuh");
+        let lib_file = out_dir.join("libkernels.a");
+
+        // Create initial version
+        fs::write(
+            &cu_file,
+            "#include \"header.cuh\"\nextern \"C\" __global__ void add() {}",
+        )
+        .unwrap();
+        fs::write(&cuh_file, "// version 1").unwrap();
+
+        let builder = KernelBuilder::new()
+            .source_files(vec![&cu_file])
+            .watch(vec![&cuh_file])
+            .out_dir(&out_dir);
+
+        // First build
+        builder.build_lib(&lib_file).expect("First build failed");
+        let mtime1 = fs::metadata(&lib_file)
+            .expect("Lib file should exist")
+            .modified()
+            .unwrap();
+
+        std::thread::sleep(Duration::from_millis(1100));
+
+        // Modify the watched header
+        fs::write(&cuh_file, "// version 2").unwrap();
+
+        // Second build - should trigger recompilation
+        builder.build_lib(&lib_file).expect("Second build failed");
+        let mtime2 = fs::metadata(&lib_file)
+            .expect("Lib file should exist after second build")
+            .modified()
+            .unwrap();
+
+        let recompiled = mtime2 > mtime1;
+
+        // Cleanup BEFORE assertion so we don't leave mess on failure
+        let _ = fs::remove_dir_all(&root);
+
+        assert!(
+            recompiled,
+            "Recompilation was NOT triggered by header change!"
+        );
     }
 }

--- a/src/compute_cap.rs
+++ b/src/compute_cap.rs
@@ -51,11 +51,7 @@ impl GpuArch {
         })?;
 
         // Normalize (accept both 80 and 8.0 style)
-        let base = if base < 20 {
-            base * 10
-        } else {
-            base
-        };
+        let base = if base < 20 { base * 10 } else { base };
 
         // If explicit suffix provided, use it; otherwise auto-suffix for >=90
         if explicit_suffix.is_some() {

--- a/src/compute_cap.rs
+++ b/src/compute_cap.rs
@@ -40,10 +40,10 @@ impl GpuArch {
         let s = s.strip_prefix("sm_").unwrap_or(&s);
 
         // Check for suffix (letters at the end)
-        let (num_part, explicit_suffix) = if s.ends_with('a') {
-            (&s[..s.len() - 1], Some("a".to_string()))
+        let (num_part, explicit_suffix) = if let Some(stripped) = s.strip_suffix('a') {
+            (stripped, Some("a".to_string()))
         } else {
-            (s.as_ref(), None)
+            (s, None)
         };
 
         let base = num_part.parse::<usize>().map_err(|_| {
@@ -51,7 +51,7 @@ impl GpuArch {
         })?;
 
         // Normalize (accept both 80 and 8.0 style)
-        let base = if base < 100 && base < 20 {
+        let base = if base < 20 {
             base * 10
         } else {
             base
@@ -121,21 +121,12 @@ impl From<usize> for GpuArch {
 }
 
 /// Compute capability configuration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ComputeCapability {
     /// Default compute cap (auto-detected or manually set)
     default_cap: Option<GpuArch>,
     /// Per-file overrides (filename pattern -> compute cap)
     overrides: HashMap<String, GpuArch>,
-}
-
-impl Default for ComputeCapability {
-    fn default() -> Self {
-        Self {
-            default_cap: None,
-            overrides: HashMap::new(),
-        }
-    }
 }
 
 impl ComputeCapability {
@@ -286,11 +277,11 @@ fn matches_pattern(filename: &str, pattern: &str) -> bool {
         }
 
         // Handle single * at start or end
-        if pattern.starts_with('*') {
-            return filename.ends_with(&pattern[1..]);
+        if let Some(stripped) = pattern.strip_prefix('*') {
+            return filename.ends_with(stripped);
         }
-        if pattern.ends_with('*') {
-            return filename.starts_with(&pattern[..pattern.len() - 1]);
+        if let Some(stripped) = pattern.strip_suffix('*') {
+            return filename.starts_with(stripped);
         }
     }
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -3,7 +3,7 @@
 use crate::error::{Error, Result};
 use fs2::FileExt;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Well-known CUTLASS repository configuration
@@ -84,7 +84,7 @@ impl ExternalDependency {
     /// to avoid re-cloning on subsequent builds.
     ///
     /// Uses file locking to prevent concurrent builds from conflicting.
-    pub fn fetch(&self, out_dir: &PathBuf) -> Result<PathBuf> {
+    pub fn fetch(&self, out_dir: &Path) -> Result<PathBuf> {
         // Use global cache directory, with out_dir as fallback
         let cache_dir = cudaforge_git_cache_dir(out_dir)?;
 
@@ -149,7 +149,7 @@ impl ExternalDependency {
     }
 
     /// Get include path arguments for nvcc
-    pub fn include_args(&self, base_dir: &PathBuf) -> Vec<String> {
+    pub fn include_args(&self, base_dir: &Path) -> Vec<String> {
         let mut args = Vec::new();
 
         // Add root directory
@@ -176,7 +176,7 @@ impl ExternalDependency {
         Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 
-    fn clone_repo(&self, target_dir: &PathBuf) -> Result<()> {
+    fn clone_repo(&self, target_dir: &Path) -> Result<()> {
         println!("cargo:warning=Cloning {} from {}", self.name, self.repo_url);
 
         let target_dir_str = target_dir
@@ -277,7 +277,7 @@ impl ExternalDependency {
     /// This can happen when:
     /// - A previous git operation was interrupted
     /// - Multiple parallel builds try to access the same cached repo
-    fn cleanup_git_locks(&self, dir: &PathBuf) {
+    fn cleanup_git_locks(&self, dir: &Path) {
         let git_dir = dir.join(".git");
         let lock_files = [
             git_dir.join("index.lock"),
@@ -355,7 +355,7 @@ impl DependencyManager {
     }
 
     /// Fetch all dependencies and return include arguments
-    pub fn fetch_all(&self, out_dir: &PathBuf) -> Result<Vec<String>> {
+    pub fn fetch_all(&self, out_dir: &Path) -> Result<Vec<String>> {
         let mut include_args = Vec::new();
 
         // Add local includes first
@@ -375,7 +375,7 @@ impl DependencyManager {
     }
 
     /// Fetch a specific dependency and return its checkout root.
-    pub fn fetch_dependency(&self, name: &str, out_dir: &PathBuf) -> Result<PathBuf> {
+    pub fn fetch_dependency(&self, name: &str, out_dir: &Path) -> Result<PathBuf> {
         let dep = self
             .dependencies
             .iter()
@@ -443,7 +443,7 @@ pub fn resolve_cutlass_from_cargo_checkouts() -> Option<PathBuf> {
 /// 3. `~/.cargo/git/checkouts/` as fallback (reuses Cargo's cache)
 ///
 /// Creates the directory if it doesn't exist.
-fn cudaforge_git_cache_dir(fallback_dir: &PathBuf) -> Result<PathBuf> {
+fn cudaforge_git_cache_dir(fallback_dir: &Path) -> Result<PathBuf> {
     let cache_dir = if let Ok(cudaforge_home) = std::env::var("CUDAFORGE_HOME") {
         PathBuf::from(cudaforge_home).join("git").join("checkouts")
     } else if let Ok(home) = std::env::var("HOME") {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+use walkdir;
 
 const CACHE_FILENAME: &str = ".cudaforge_cache.json";
 
@@ -25,6 +26,9 @@ pub struct BuildCache {
 pub struct CacheEntry {
     /// SHA-256 hash of file content
     pub content_hash: String,
+    /// Combined hash of watched paths
+    #[serde(default)]
+    pub watch_hash: String,
     /// Last modification time (Unix timestamp)
     pub modified_time: u64,
     /// Path to compiled object file
@@ -79,6 +83,7 @@ impl BuildCache {
         object_path: &Path,
         gpu_arch: &str,
         args_hash: &str,
+        watch_hash: &str,
     ) -> bool {
         let key = source_path.to_string_lossy().to_string();
 
@@ -93,8 +98,8 @@ impl BuildCache {
             None => return true,
         };
 
-        // Check if gpu arch or args changed
-        if entry.gpu_arch != gpu_arch || entry.args_hash != args_hash {
+        // Check if gpu arch, args, or watched paths changed
+        if entry.gpu_arch != gpu_arch || entry.args_hash != args_hash || entry.watch_hash != watch_hash {
             return true;
         }
 
@@ -122,6 +127,7 @@ impl BuildCache {
         object_path: &Path,
         gpu_arch: &str,
         args_hash: &str,
+        watch_hash: &str,
     ) -> Result<()> {
         let key = source_path.to_string_lossy().to_string();
         let content_hash = hash_file(source_path)?;
@@ -140,6 +146,7 @@ impl BuildCache {
             key,
             CacheEntry {
                 content_hash,
+                watch_hash: watch_hash.to_string(),
                 modified_time,
                 object_path: object_path.to_string_lossy().to_string(),
                 gpu_arch: gpu_arch.to_string(),
@@ -182,6 +189,49 @@ pub fn hash_args(args: &[String]) -> String {
         hasher.update(arg.as_bytes());
         hasher.update(b"\0");
     }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Compute a combined hash of multiple paths (files or directories)
+pub fn hash_paths(paths: &[PathBuf]) -> String {
+    let mut hasher = Sha256::new();
+    
+    // Sort paths to ensure deterministic hashing
+    let mut sorted_paths = paths.to_vec();
+    sorted_paths.sort();
+
+    for path in sorted_paths {
+        if path.is_file() {
+            if let Ok(h) = hash_file(&path) {
+                hasher.update(path.to_string_lossy().as_bytes());
+                hasher.update(b":");
+                hasher.update(h.as_bytes());
+                hasher.update(b"\0");
+            }
+        } else if path.is_dir() {
+            // For directories, we hash all .h and .cuh files recursively
+            let mut entries: Vec<_> = walkdir::WalkDir::new(&path)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    let p = e.path();
+                    p.is_file() && matches!(p.extension().and_then(|s| s.to_str()), Some("h" | "cuh" | "hpp"))
+                })
+                .collect();
+            
+            entries.sort_by(|a, b| a.path().cmp(b.path()));
+
+            for entry in entries {
+                if let Ok(h) = hash_file(entry.path()) {
+                    hasher.update(entry.path().to_string_lossy().as_bytes());
+                    hasher.update(b":");
+                    hasher.update(h.as_bytes());
+                    hasher.update(b"\0");
+                }
+            }
+        }
+    }
+    
     format!("{:x}", hasher.finalize())
 }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
-use walkdir;
+// redundant walkdir import removed
 
 const CACHE_FILENAME: &str = ".cudaforge_cache.json";
 
@@ -99,7 +99,10 @@ impl BuildCache {
         };
 
         // Check if gpu arch, args, or watched paths changed
-        if entry.gpu_arch != gpu_arch || entry.args_hash != args_hash || entry.watch_hash != watch_hash {
+        if entry.gpu_arch != gpu_arch
+            || entry.args_hash != args_hash
+            || entry.watch_hash != watch_hash
+        {
             return true;
         }
 
@@ -195,7 +198,7 @@ pub fn hash_args(args: &[String]) -> String {
 /// Compute a combined hash of multiple paths (files or directories)
 pub fn hash_paths(paths: &[PathBuf]) -> String {
     let mut hasher = Sha256::new();
-    
+
     // Sort paths to ensure deterministic hashing
     let mut sorted_paths = paths.to_vec();
     sorted_paths.sort();
@@ -215,10 +218,14 @@ pub fn hash_paths(paths: &[PathBuf]) -> String {
                 .filter_map(|e| e.ok())
                 .filter(|e| {
                     let p = e.path();
-                    p.is_file() && matches!(p.extension().and_then(|s| s.to_str()), Some("h" | "cuh" | "hpp"))
+                    p.is_file()
+                        && matches!(
+                            p.extension().and_then(|s| s.to_str()),
+                            Some("h" | "cuh" | "hpp")
+                        )
                 })
                 .collect();
-            
+
             entries.sort_by(|a, b| a.path().cmp(b.path()));
 
             for entry in entries {
@@ -231,7 +238,7 @@ pub fn hash_paths(paths: &[PathBuf]) -> String {
             }
         }
     }
-    
+
     format!("{:x}", hasher.finalize())
 }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -162,10 +162,19 @@ impl BuildCache {
 
     /// Remove stale entries (files that no longer exist)
     pub fn cleanup(&mut self) {
-        self.entries.retain(|path, entry| {
-            Path::new(path).exists() && Path::new(&entry.object_path).exists()
+        self.entries.retain(|key, entry| {
+            let source_exists = source_path_from_key(key, &entry.object_path)
+                .map(Path::new)
+                .is_some_and(Path::exists);
+
+            source_exists && Path::new(&entry.object_path).exists()
         });
     }
+}
+
+fn source_path_from_key<'a>(key: &'a str, object_path: &str) -> Option<&'a str> {
+    let suffix = format!(":{}", object_path);
+    key.strip_suffix(&suffix)
 }
 
 /// Compute SHA-256 hash of a file's contents
@@ -267,6 +276,7 @@ pub fn output_is_current(output: &Path, inputs: &[PathBuf]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn test_hash_args() {
@@ -276,5 +286,46 @@ mod tests {
 
         assert_eq!(hash_args(&args1), hash_args(&args2));
         assert_ne!(hash_args(&args1), hash_args(&args3));
+    }
+
+    #[test]
+    fn test_cleanup_retains_valid_composite_key_entries() {
+        let mut root = std::env::temp_dir();
+        root.push(format!("cudaforge-hash-test-{}", std::process::id()));
+
+        if root.exists() {
+            let _ = fs::remove_dir_all(&root);
+        }
+        fs::create_dir_all(&root).unwrap();
+
+        let source_path = root.join("kernel.cu");
+        let object_path = root.join("kernel.o");
+        fs::write(&source_path, "__global__ void kernel() {}").unwrap();
+        fs::write(&object_path, "object").unwrap();
+
+        let mut cache = BuildCache::default();
+        cache
+            .update(&source_path, &object_path, "sm_80", "args", "watch")
+            .unwrap();
+
+        cache.cleanup();
+        assert_eq!(cache.entries.len(), 1);
+
+        fs::remove_file(&source_path).unwrap();
+        cache.cleanup();
+        assert!(cache.entries.is_empty());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn test_source_path_from_key_with_colons_in_paths() {
+        let key = "/tmp/src:dir/kernel.cu:/tmp/out:dir/kernel.o";
+        let object_path = "/tmp/out:dir/kernel.o";
+
+        assert_eq!(
+            source_path_from_key(key, object_path),
+            Some("/tmp/src:dir/kernel.cu")
+        );
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -85,7 +85,7 @@ impl BuildCache {
         args_hash: &str,
         watch_hash: &str,
     ) -> bool {
-        let key = source_path.to_string_lossy().to_string();
+        let key = format!("{}:{}", source_path.display(), object_path.display());
 
         // Check if object file exists
         if !object_path.exists() {
@@ -132,7 +132,7 @@ impl BuildCache {
         args_hash: &str,
         watch_hash: &str,
     ) -> Result<()> {
-        let key = source_path.to_string_lossy().to_string();
+        let key = format!("{}:{}", source_path.display(), object_path.display());
         let content_hash = hash_file(source_path)?;
 
         let modified_time = source_path

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -90,10 +90,8 @@ impl ParallelConfig {
             if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
                 if let Ok(compiled) = Pattern::new(pattern) {
                     // 1. Try matching against the filename component (if pattern has no path separators)
-                    if !pattern.contains('/') && !pattern.contains('\\') {
-                        if compiled.matches(filename_component) {
-                            return true;
-                        }
+                    if !pattern.contains('/') && !pattern.contains('\\') && compiled.matches(filename_component) {
+                        return true;
                     }
 
                     // 2. Try matching against the full path

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -90,7 +90,10 @@ impl ParallelConfig {
             if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
                 if let Ok(compiled) = Pattern::new(pattern) {
                     // 1. Try matching against the filename component (if pattern has no path separators)
-                    if !pattern.contains('/') && !pattern.contains('\\') && compiled.matches(filename_component) {
+                    if !pattern.contains('/')
+                        && !pattern.contains('\\')
+                        && compiled.matches(filename_component)
+                    {
                         return true;
                     }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -140,7 +140,10 @@ impl SourceSelector {
     fn collect_from_directory(&self, dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
         for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
             let path = entry.path();
-            if path.is_file() && path.extension().is_some_and(|e| e == "cu") && !self.is_excluded(path) {
+            if path.is_file()
+                && path.extension().is_some_and(|e| e == "cu")
+                && !self.is_excluded(path)
+            {
                 files.push(path.to_path_buf());
             }
         }

--- a/src/source.rs
+++ b/src/source.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// Source file selection configuration
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SourceSelector {
     /// Included files/directories
     includes: Vec<SourcePath>,
@@ -21,16 +21,6 @@ enum SourcePath {
     File(PathBuf),
     Directory(PathBuf),
     Glob(String),
-}
-
-impl Default for SourceSelector {
-    fn default() -> Self {
-        Self {
-            includes: Vec::new(),
-            excludes: Vec::new(),
-            watch_paths: Vec::new(),
-        }
-    }
 }
 
 impl SourceSelector {
@@ -124,7 +114,7 @@ impl SourceSelector {
                     SourcePath::Glob(pattern) => {
                         if let Ok(entries) = glob::glob(pattern) {
                             for entry in entries.flatten() {
-                                if entry.extension().map_or(false, |e| e == "cu")
+                                if entry.extension().is_some_and(|e| e == "cu")
                                     && !self.is_excluded(&entry)
                                 {
                                     files.push(entry);
@@ -150,10 +140,8 @@ impl SourceSelector {
     fn collect_from_directory(&self, dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
         for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
             let path = entry.path();
-            if path.is_file() && path.extension().map_or(false, |e| e == "cu") {
-                if !self.is_excluded(path) {
-                    files.push(path.to_path_buf());
-                }
+            if path.is_file() && path.extension().is_some_and(|e| e == "cu") && !self.is_excluded(path) {
+                files.push(path.to_path_buf());
             }
         }
         Ok(())
@@ -192,11 +180,11 @@ fn matches_exclusion_pattern(filename: &str, path_str: &str, pattern: &str) -> b
             let (prefix, suffix) = (parts[0], parts[1]);
             return filename.starts_with(prefix) && filename.ends_with(suffix);
         }
-        if pattern.starts_with('*') {
-            return filename.ends_with(&pattern[1..]);
+        if let Some(stripped) = pattern.strip_prefix('*') {
+            return filename.ends_with(stripped);
         }
-        if pattern.ends_with('*') {
-            return filename.starts_with(&pattern[..pattern.len() - 1]);
+        if let Some(stripped) = pattern.strip_suffix('*') {
+            return filename.starts_with(stripped);
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue where modifications to header files (.cuh) added via the .watch() method did not always trigger a recompilation.
## Problem
The BuildCache (internal incremental build system) only considered the hash of the main .cu source file when deciding whether to re-run nvcc. It ignored the state of paths specified in the .watch() list, leading to skipped recompilations even when headers were modified.
## Changes
- Build Cache: Added watch_hash to CacheEntry to track the state of all watched files and directories.
- Path Hashing: Implemented recursive hashing for watched paths in src/hash.rs.
- Kernel Builder: Updated build_lib and build_ptx to validate the watch_hash before skipping compilation.

<details>

<summary><b>Optional</b>: - Regression Test: Integrated test_incremental_rebuild_on_header_change into src/builder.rs to ensure this scenario is covered.</summary>

### In src/builder.rs

```rust
#[cfg(test)]
mod tests {
    use super::*;
    use std::fs;
    use std::time::Duration;

    #[test]
    fn test_incremental_rebuild_on_header_change() {
        // Skip test if nvcc is not available (e.g. in some CI environments)
        if crate::toolkit::CudaToolkit::detect().is_err() {
            return;
        }

        // Use a semi-unique directory in the system temp folder
        let mut root = std::env::temp_dir();
        root.push(format!("cudaforge-test-{}", std::process::id()));
        
        // Ensure clean state
        if root.exists() {
            let _ = fs::remove_dir_all(&root);
        }
        fs::create_dir_all(&root).unwrap();

        let out_dir = root.join("out");
        let src_dir = root.join("src");
        fs::create_dir_all(&out_dir).unwrap();
        fs::create_dir_all(&src_dir).unwrap();

        let cu_file = src_dir.join("kernel.cu");
        let cuh_file = src_dir.join("header.cuh");
        let lib_file = out_dir.join("libkernels.a");

        // Create initial version
        fs::write(&cu_file, "#include \"header.cuh\"\nextern \"C\" __global__ void add() {}").unwrap();
        fs::write(&cuh_file, "// version 1").unwrap();

        let builder = KernelBuilder::new()
            .source_files(vec![&cu_file])
            .watch(vec![&cuh_file])
            .out_dir(&out_dir);
        
        // First build
        builder.build_lib(&lib_file).expect("First build failed");
        let mtime1 = fs::metadata(&lib_file).expect("Lib file should exist").modified().unwrap();

        std::thread::sleep(Duration::from_millis(1100));

        // Modify the watched header
        fs::write(&cuh_file, "// version 2").unwrap();

        // Second build - should trigger recompilation
        builder.build_lib(&lib_file).expect("Second build failed");
        let mtime2 = fs::metadata(&lib_file).expect("Lib file should exist after second build").modified().unwrap();

        let recompiled = mtime2 > mtime1;
        
        // Cleanup BEFORE assertion so we don't leave mess on failure
        let _ = fs::remove_dir_all(&root);

        assert!(recompiled, "Recompilation was NOT triggered by header change!");
    }
}
```

</details>

## Verification
- Verified that modification of a watched .cuh file now correctly triggers a re-run of nvcc.
- Confirmed that the cache remains backward compatible with existing .cudaforge_cache.json files.
- Ran cargo clippy and cargo test to ensure all fixes are correct and follow Rust best practices.