### PR TITLE
fix: pass /Zc:preprocessor to MSVC host compiler for CUDA 13.x

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -491,6 +491,8 @@ impl KernelBuilder {
                     command.arg("-Xcompiler").arg("-fPIC");
                 } else {
                     command.arg("-D_USE_MATH_DEFINES");
+                    // CUDA 13.x CCCL headers reject MSVC's traditional preprocessor.
+                    command.arg("-Xcompiler").arg("/Zc:preprocessor");
                 }
                 crt_args.add_to_command(&mut command);
                 if let Some(cudart) = &self.cudart {
@@ -601,6 +603,7 @@ impl KernelBuilder {
 
         let dep_args = self.dependencies.fetch_all(&self.out_dir)?;
         let ccbin_env = std::env::var("NVCC_CCBIN").ok();
+        let is_msvc = std::env::var("TARGET").is_ok_and(|t| t.contains("msvc"));
         let nvcc_threads = self.parallel.nvcc_threads();
         let watch_hash = hash_paths(self.sources.watch_paths());
         let mut cache = BuildCache::load(&self.out_dir);
@@ -673,6 +676,10 @@ impl KernelBuilder {
                     command
                         .arg("-allow-unsupported-compiler")
                         .args(["-ccbin", ccbin]);
+                }
+                // CUDA 13.x CCCL headers reject MSVC's traditional preprocessor.
+                if is_msvc {
+                    command.arg("-Xcompiler").arg("/Zc:preprocessor");
                 }
 
                 // Add nvcc threads for certain files


### PR DESCRIPTION
## Problem

Fixes #10.

On Windows with **CUDA 13.x**, compiling `.cu` files through `KernelBuilder` fails:

```
...\CUDA\v13.2\include\cccl\cuda/std/__cccl/preprocessor.h(20): fatal error C1189:
#error: MSVC/cl.exe with traditional preprocessor is used. ... Please switch to the
standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe.
```

CUDA 13.x CCCL headers hard-`#error` unless the MSVC host compiler runs with its conforming preprocessor. `KernelBuilder` currently passes `-D_USE_MATH_DEFINES` on MSVC but never forwards `/Zc:preprocessor`. `build_ptx()` has no MSVC handling at all, so even PTX kernels (e.g. `reduce.cu`) fail.

## Change

Add `/Zc:preprocessor` via `-Xcompiler` on MSVC in both compile paths:

- `build_lib`: in the existing `is_msvc` branch alongside `-D_USE_MATH_DEFINES`.
- `build_ptx`: compute `is_msvc` from `TARGET` (it wasn't computed before) and inject the flag in the compile closure.

This mirrors the existing `-fPIC` / `-D_USE_MATH_DEFINES` handling and is a no-op on non-MSVC targets.

## Verification

- `cargo fmt`, `cargo clippy --all-targets`, `cargo check` clean.
- `cargo test` (with the VS C++ toolchain on PATH) passes 25/25 on Windows 11 + CUDA 13.x + MSVC 19.50, building real kernels through nvcc.

## Context

Surfaced while building [mistral.rs](https://github.com/EricLBuehler/mistral.rs) with CUDA on Windows (EricLBuehler/mistral.rs#2082), where `candle-kernels` compiles through cudaforge and hit C1189.